### PR TITLE
Docs sweep: typos & punctuation across Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Python-tools-for-Google
 <!-- </h1> -->
 
-Building a Python package for working with Google Services, including GCP and Google Drive
+Building a Python package for working with Google Services, including GCP and Google Drive.
 
 ## Set up
 1. Create and activate a Python virtual environment in your working directory:
@@ -28,7 +28,7 @@ Building a Python package for working with Google Services, including GCP and Go
 	from python_utils.bigquery import *
 	from python_utils.utils import *
 	```
-7. Feel free to expand the `python_utils` folder with your custom modules that is needed for any projects.
+7. Feel free to expand the `python_utils` folder with custom modules that are needed for any projects.
 
 ---
 
@@ -40,7 +40,7 @@ Building a Python package for working with Google Services, including GCP and Go
 - #### **[google_drive.py](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/google_drive.md)**
 	- Class and methods for working with Google Drive
 
-- #### **[gcs_bucket.py](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/google_drive.md)**
+- #### **[gcs_bucket.py](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/gcs_bucket.md)**
 	- Functions for working with Google Cloud Storage Bucket
 
 - #### **[api.py](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/api.md)**

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,9 +3,9 @@
 ## Set up
 
 1. Include the following:
-	- OAuth2 client credentials 
-	- Access token url
-	- Base url for API endpoints, to easily combine with the API endpoint urls
+        - OAuth2 client credentials
+        - Access token URL
+        - Base URL for API endpoints, to easily combine with the API endpoint URLs
 2. Recommended: store the client credentials in the environment or use Secret Manager and access the secret using service account credentials.
 
 ```py
@@ -25,10 +25,10 @@ def gen_access_token(token_url:str, client_id:str, client_secret:str, api_base_u
 ```
 
 #### **Parameters:**
-- `token_url`: The url used to generate access token using OAuth2 to send API requests.
+- `token_url`: The URL used to generate an access token using OAuth2 to send API requests.
 - `client_id`: ID or username of the OAuth2 client.
-- `client_secret`: Oauth2 client password.
-- `api_base_url`: Base url for all API endpoints you are working with.
+- `client_secret`: OAuth2 client password.
+- `api_base_url`: Base URL for all API endpoints you are working with.
 
 #### **Function call:**
 ```py
@@ -41,11 +41,11 @@ access_token = gen_access_token(
 ```
 
 #### **Use case:**
-Generate access token based on OAuth2 Client credentials. The token is used for authentication when sending API requests.
+Generate an access token based on OAuth2 client credentials. The token is used for authentication when sending API requests.
 
 #### **Return value:**
 - Type: string
-- Returns a string acces token to be used when sending API requests.
+- Returns a string access token to be used when sending API requests.
 
 
 ---
@@ -58,8 +58,8 @@ def api_get(access_token:str, api_url:str, content_type:str=None, params:dict=No
 ```
 
 #### **Parameters:**
-- `access_token`: Access toke string generated from [`gen_access_token`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/api.md#gen_access_token).
-- `api_url`: The url of the API endpoint your script/programme is communicating with.
+- `access_token`: Access token string generated from [`gen_access_token`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/api.md#gen_access_token).
+- `api_url`: The URL of the API endpoint your script/program is communicating with.
 - `content_type`: The content type of the data payload to be received. The standard is `'application/json'`.
 
 #### **Function call:**
@@ -83,7 +83,7 @@ api_response = api_get(
 ```
 
 #### **Use case:**
-Send API get requests and receive a data payload.
+Send API GET requests and receive a data payload.
 
 #### **Return value:**
 - Type: Any

--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -3,7 +3,7 @@
 <!-- </h1> -->
 
 ## Set up
-1. Create a BigQuery API client object using your service account key. The API client allows your Python script/programme to communicate with BigQuery.
+1. Create a BigQuery API client object using your service account key. The API client allows your Python script/program to communicate with BigQuery.
 
 2. You can now include the API client object in your function calls.
 
@@ -34,9 +34,9 @@ def df_to_bq(bq_client, df:pd.DataFrame, table_id:str, mode:str, schema=None, au
 
 #### **Parameters:**
 - `bq_client`: BigQuery API client object created during [set up](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#set-up).
-- `df`: The Pandas Dataframe containing the data to be uploaded to BigQuery.
+- `df`: The Pandas DataFrame containing the data to be uploaded to BigQuery.
 - `mode`: `'a'` to append to table and `'t'` to truncate table.
-- `table_id`: Id of the BigQuery for the data to be uploaded to. Usually in `project_id.dataset_name_table_name`.
+- `table_id`: ID of the BigQuery table for the data to be uploaded. Usually in `project_id.dataset_name.table_name`.
 - `schema`: Schema definition for the data to be uploaded. This hard-sets the data type of the uploaded data. See the expandable part in [function call](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#function-call) on how to define a BigQuery schema in Python code.
 - `autodetect`: If `True`, automatically creates a new table if the current `table_id` doesn't exist.
 
@@ -71,7 +71,7 @@ df_to_bq(
 ```
 
 #### **Use case:**
-Loads data from Python Pandas Dataframe to BigQuery.
+Loads data from a Python Pandas DataFrame to BigQuery.
 
 #### **Return value:**
 No return value.
@@ -88,7 +88,7 @@ def bq_to_df(bq_client, sql_script:str, replace_in_query:list=[], log=False, ign
 #### **Parameters:**
 - `bq_client`: BigQuery API client object created during [set up](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#set-up).
 - `sql_script`: File path to the SQL script to query data from BigQuery.
-- `replace_in_query`: Search and replace parts in your SQL script. Best for repititive queries.
+- `replace_in_query`: Search and replace parts in your SQL script. Best for repetitive queries.
 - `log`: `True` to enable printing messages for logging. `False` otherwise.
 - `ignore_error`: `True` to continue the extraction process even if error occurs. `False` otherwise.
 
@@ -97,7 +97,7 @@ def bq_to_df(bq_client, sql_script:str, replace_in_query:list=[], log=False, ign
 <summary>Example query (with parts to replace)</summary>
 
 - Replace `cur_dept` with `"1%"`, `"2%"` etc. The function can then be called in a for loop to query for each department.
-- Replace table_id `project_id.dataset.table` with `project_id.dataset.table01`. The dunction can be called in a for loop to query for table 01-05.
+ - Replace table_id `project_id.dataset.table` with `project_id.dataset.table01`. The function can be called in a for loop to query for table 01-05.
 
 ```sql
 SELECT *
@@ -121,10 +121,10 @@ results_df = bq_to_df(
 ```
 
 #### **Use case:**
-Extract BigQuery query results into a Pandas Dataframe.
+Extract BigQuery query results into a Pandas DataFrame.
 
 #### **Return value:**
-Pandas Dataframe containing query results.
+Pandas DataFrame containing query results.
 
 ---
 
@@ -136,9 +136,9 @@ def df_to_csv(df:pd.DataFrame, slice_row:int, outfile_path:str, sep:str=',', dlt
 ```
 
 #### **Parameters:**
-- `df`: The dataframe to be exported to local CSV file.
-- `slice_row`: Slice the data by every n rows. E.g. `slice_row = 10` from a dataframe containing 100 rows will produce 10 output files, each with 10 different rows of data. Accept values 0 to 1000000 (0 = no slicing).
-- `sep`: The seperator for the CSV file. Uses comma `,` by default but can be changed to `|` or other symbols if the data contains commas.
+- `df`: The DataFrame to be exported to a local CSV file.
+- `slice_row`: Slice the data by every n rows. E.g. `slice_row = 10` from a DataFrame containing 100 rows will produce 10 output files, each with 10 different rows of data. Accept values 0 to 1,000,000 (0 = no slicing).
+- `sep`: The separator for the CSV file. Uses comma `,` by default but can be changed to `|` or other symbols if the data contains commas.
 - `outfile_path`: Full path to the resulting CSV file.
 - `dlt_dir`: `True` to remove the output folder for the local files. `False` otherwise.
 - `log`: `True` to enable printing messages for logging. `False` otherwise.
@@ -158,7 +158,7 @@ df_to_csv(
 ```
 
 #### **Use case:**
-Export Pandas Dataframe data to a local CSV file.
+Export Pandas DataFrame data to a local CSV file.
 
 #### **Return value:**
 No return value.
@@ -172,8 +172,8 @@ def df_to_excel(df: pd.DataFrame, slice_row: int, outfile_path: str, log: bool =
 ```
 
 #### **Parameters:**
-- `df`: The dataframe to be exported to local Excel file.
-- `slice_row`: Slice the data by every n rows. E.g. `slice_row = 10` from a dataframe containing 100 rows will produce 10 output files, each with 10 different rows of data. Accept values 0 to 1000000 (0 = no slicing).
+- `df`: The DataFrame to be exported to a local Excel file.
+- `slice_row`: Slice the data by every n rows. E.g. `slice_row = 10` from a DataFrame containing 100 rows will produce 10 output files, each with 10 different rows of data. Accept values 0 to 1,000,000 (0 = no slicing).
 - `outfile_path`: Full path to the resulting Excel file.
 - `dlt_dir`: `True` to remove the output folder for the local files. `False` otherwise.
 - `log`: `True` to enable printing messages for logging. `False` otherwise.
@@ -192,7 +192,7 @@ df_to_excel(
 ```
 
 #### **Use case:**
-Export Pandas Dataframe data to a local Excel file.
+Export Pandas DataFrame data to a local Excel file.
 
 #### **Return value:**
 No return value.
@@ -207,9 +207,9 @@ def df_to_csv_bin(df:pd.DataFrame, slice_row:int, outfile_name:str, sep:str=',',
 ```
 
 #### **Parameters:**
-- `df`: The dataframe to be exported to binary CSV file.
-- `slice_row`: Slice the data by every n rows. E.g. `slice_row = 10` from a dataframe containing 100 rows will produce 10 binary CSV files, each with 10 different rows of data. Accept values 0 to 1000000 (0 = no slicing).
-- `sep`: The seperator for the binary CSV file. Uses comma `,` by default but can be changed to `|` or other symbols if the data contains commas.
+- `df`: The DataFrame to be exported to a binary CSV file.
+- `slice_row`: Slice the data by every n rows. E.g. `slice_row = 10` from a DataFrame containing 100 rows will produce 10 binary CSV files, each with 10 different rows of data. Accept values 0 to 1,000,000 (0 = no slicing).
+- `sep`: The separator for the binary CSV file. Uses comma `,` by default but can be changed to `|` or other symbols if the data contains commas.
 - `outfile_name`: Name of the resulting binary CSV file.
 - `log`: `True` to enable printing messages for logging. `False` otherwise.
 - `ignore_error`: `True` to continue the extraction process even if error occurs. `False` otherwise.
@@ -227,14 +227,14 @@ csv_bin_files = df_to_csv_bin(
 ```
 
 #### **Use case:**
-- Export Pandas Dataframe to binary CSV file.
-- Best used when writing large query results into CSV files that does not need to be stored locally.
+ - Export Pandas DataFrame to binary CSV file.
+ - Best used when writing large query results into CSV files that do not need to be stored locally.
 - This saves I/O overhead for workloads such as data export where files don't need to be stored in the machine as the binary files reside in memory during runtime.
 - E.g. Exporting query results as CSV to Google Drive. This is used in conjunction with the [`bin_file_to_drive`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/google_drive.md#bin_file_to_drive) function.
 
 #### **Return value:**
 - Type: List of tuples.
-- Returns a list of file name and file buffer pair: `[(file_name1, file_buffer1), (file_name2, file_buffer2)]`. The file buffer contains the binary data of the output CSV file.
+ - Returns a list of file name and file buffer pairs: `[(file_name1, file_buffer1), (file_name2, file_buffer2)]`. The file buffer contains the binary data of the output CSV file.
 
 ---
 
@@ -246,8 +246,8 @@ def df_to_excel_bin(df, slice_row:int, outfile_name:str, log=False, ignore_eror=
 ```
 
 #### **Parameters:**
-- `df`: The dataframe to be exported to binary Excel file.
-- `slice_row`: Slice the data by every n rows. E.g. `slice_row = 10` from a dataframe containing 100 rows will produce 10 binary Excel files, each with 10 different rows of data. Accept values 0 to 1000000 (0 = no slicing).
+- `df`: The DataFrame to be exported to a binary Excel file.
+- `slice_row`: Slice the data by every n rows. E.g. `slice_row = 10` from a DataFrame containing 100 rows will produce 10 binary Excel files, each with 10 different rows of data. Accept values 0 to 1,000,000 (0 = no slicing).
 - `outfile_name`: Name of the resulting binary Excel file.
 - `log`: `True` to enable printing messages for logging. `False` otherwise.
 - `ignore_error`: `True` to continue the extraction process even if error occurs. `False` otherwise.
@@ -264,11 +264,12 @@ excel_bin_files = df_to_excel_bin(
 ```
 
 #### **Use case:**
-- Export Pandas Dataframe to binary Excel file.
-- Best used when writing large query results into binary Excel files that does not need to be stored locally.
+ - Export Pandas DataFrame to binary Excel file.
+ - Best used when writing large query results into binary Excel files that do not need to be stored locally.
 This saves I/O overhead for workloads such as data export where files don't need to be stored in the machine as the binary files reside in memory during runtime.
 - E.g. Exporting query results as Excel to Google Drive. This is used in conjunction with the [`bin_file_to_drive`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/google_drive.md#bin_file_to_drive) function.
 
 #### **Return value:**
 - Type: List of tuples.
-- Returns a list of file name and file buffer pair: `[(file_name1, file_buffer1), (file_name2, file_buffer2)]`. The file buffer contains the binary data of the output Excel file.
+ - Returns a list of file name and file buffer pairs: `[(file_name1, file_buffer1), (file_name2, file_buffer2)]`. The file buffer contains the binary data of the output Excel file.
+

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This moodule contains one dictionary only:
+This module contains one dictionary only:
 
 ```py
 content_data = {
@@ -13,15 +13,15 @@ content_data = {
 }
 ```
 
-It stores the standardisation of file extensions and their `mimetypes` used in functions for the Google services this package is used for. Hence, it is important that you do not edit the contents in this dictionary.
+It stores the standardization of file extensions and their `MIME types` used in functions for the Google services this package is used for. Hence, it is important that you do not edit the contents in this dictionary.
 
 ---
 
 ## What other developers can do:
 
-You are allowed to add definitions here, e.g. BigQuery schema definitions, and import this module into your code. This serves as a way of standardising your definitions in one place.
+You are allowed to add definitions here, e.g. BigQuery schema definitions, and import this module into your code. This serves as a way of standardizing your definitions in one place.
 
-In formats.py:
+In `formats.py`:
 
 ```py
 from google.cloud import bigquery as bq
@@ -51,3 +51,4 @@ df_to_bq(
 	autodetect:bool=True
 )
 ```
+

--- a/docs/gcs_bucket.md
+++ b/docs/gcs_bucket.md
@@ -1,9 +1,9 @@
 # gcs_bucket.py
 
 ## Set up
-1. Create a BigQuery API client object using your service account key. The API client allows your Python script/programme to communicate with BigQuery.
+1. Create a BigQuery API client object using your service account key. The API client allows your Python script/program to communicate with BigQuery.
 
-2. Create a Google Cloud Storage API client object using your service account key. The API client allows your Python script/programme to communicate with Cloud Storage and interact with Storage Buckets and Bucket objects.
+2. Create a Google Cloud Storage API client object using your service account key. The API client allows your Python script/program to communicate with Cloud Storage and interact with storage buckets and bucket objects.
 
 3. You can now include the API client object in your function calls.
 
@@ -36,7 +36,7 @@ def file_to_bucket(storage_client, bucket_id:str, bucket_dir_path:str, file_type
 
 #### **Parameters:**
 - `storage_client`: BigQuery API client created during [set up](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/gcs_bucket.md#set-up).
-- `bucket_id`: Unique name (Id) of your Bucket.
+- `bucket_id`: Unique name (ID) of your bucket.
 - `bucket_dir_path`: Path to the target directory in the Bucket. The file path is available for copy at the top.
 - `file_type`: Type of file to upload.
 - `mode`: 't' to truncate same-name files, 'i' to ignore and create a duplicate.
@@ -55,7 +55,7 @@ file_to_bucket(
 ```
 
 #### **Use case:**
-Load local files to GCS Bucket
+Load local files to a GCS bucket.
 
 #### **Return value:**
 No return value.
@@ -71,9 +71,9 @@ def bin_file_to_bucket(storage_client, bucket_id:str, bucket_dir_path:str, file_
 
 #### **Parameters:**
 - `storage_client`: BigQuery API client created during [set up](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/gcs_bucket.md#set-up).
-- `bucket_id`: Unique name (Id) of your Bucket.
+- `bucket_id`: Unique name (ID) of your bucket.
 - `bucket_dir_path`: Path to the target directory in the Bucket. The file path is available for copy at the top.
-- `file_data`: List of file name and file buffer pair: `[(file_name, file_buffer)]`, can be obtained from [`df_to_csv_bin`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#df_to_csv_bin) and [`df_to_excel_bin`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#df_to_excel_bin).
+- `file_data`: List of file name and file buffer pairs: `[(file_name, file_buffer)]`; can be obtained from [`df_to_csv_bin`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#df_to_csv_bin) and [`df_to_excel_bin`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#df_to_excel_bin).
 - `mode`: 't' to truncate same-name files, 'i' to ignore and create a duplicate.
 - `log`: Enable printing messages for logging.
 
@@ -100,7 +100,7 @@ bin_file_to_bucket(
 ```
 
 #### **Use case:**
-Upload files from memory (binary buffers) to GCS Bucket.
+Upload files from memory (binary buffers) to a GCS bucket.
 
 #### **Return value:**
 No return value.
@@ -115,13 +115,13 @@ def bucket_csv_to_bq(bq_client, bucket_dir_path:str, project_id:str, dataset_id:
 ```
 
 #### **Parameters:**
-- `bq_client` BigQuery API client object. Please refer to the [set up](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/gcs_bucket.md#set-up) section and BigQuery related functions in [bigquery.md](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md) for more information.
-- `bucket_filepath`: Path to the target CSV file in the Bucket.
+- `bq_client`: BigQuery API client object. Please refer to the [set up](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/gcs_bucket.md#set-up) section and BigQuery-related functions in [bigquery.md](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md) for more information.
+- `bucket_dir_path`: Path to the target CSV file in the bucket.
 - `project_id`: Project ID for the target table.
 - `dataset_id`: Name of the dataset that stores the target table.
 - `table_id`: Name of the target table. This combined with `project_id` and `dataset_id` will form the complete BigQuery table ID, in the form of `project_id.dataset.table`.
 - `write_mode`: `'a'` to append to table and `'t'` to truncate the table during data loading.
-- `skip_leading_row`: `1` to skip the first row of the CSV file which is usually the header. `0` to include the header as well (not recommended).
+- `skip_leading_rows`: `1` to skip the first row of the CSV file, which is usually the header. `0` to include the header as well (not recommended).
 - `schema`: Schema definition for the data to be uploaded. This hard-sets the data type of the uploaded data. See the expandable part in [function call](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/gcs_bucket.md#function-call-2) on how to define a BigQuery schema in Python code.
 - `log`: `True` to enable printing messages for logging. `False` otherwise.
 
@@ -159,7 +159,7 @@ bucket_csv_to_bq(
 ```
 
 #### **Use case:**
-Uploads data from CSV files in Google Cloud Storage Bucket to BigQuery.
+Uploads data from CSV files in a Google Cloud Storage bucket to BigQuery.
 
 #### **Return value:**
 No return value.
@@ -174,7 +174,7 @@ def bucket_excel_to_bq(bq_client, bucket_filepath:str, project_id:str, dataset_i
 ```
 
 #### **Parameters:**
-- `bq_client` BigQuery API client object. Please refer to the [set up](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/gcs_bucket.md#set-up) section and BigQuery related functions in [bigquery.md](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md) for more information.
+- `bq_client`: BigQuery API client object. Please refer to the [set up](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/gcs_bucket.md#set-up) section and BigQuery-related functions in [bigquery.md](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md) for more information.
 - `bucket_filepath`: Path to the target Excel file in the Bucket.
 - `project_id`: Project ID for the target table.
 - `dataset_id`: Name of the dataset that stores the target table.
@@ -198,7 +198,8 @@ bucket_excel_to_bq(
 ```
 
 #### **Use case:**
-Uploads data from Excel files in Google Cloud Storage Bucket to BigQuery.
+Uploads data from Excel files in a Google Cloud Storage bucket to BigQuery.
 
 #### **Return value:**
 No return value.
+

--- a/docs/google_drive.md
+++ b/docs/google_drive.md
@@ -2,9 +2,9 @@
 
 ## Set up
 
-1. Add a service account to the target Google Drive an editor. 
+1. Add a service account to the target Google Drive as an editor.
 
-2. Create a Google Drive API client service object using the service account key. This allows your Python script/programme to communicate with Google Drive.
+2. Create a Google Drive API client service object using the service account key. This allows your Python script/program to communicate with Google Drive.
 
 ```py
 from python_utils.google_drive import build_drive_service
@@ -37,7 +37,7 @@ target_drive = Google_Drive(service, is_shared_drive=True, main_drive_id="0ABcDe
 
 **Parameters:**
 - `is_shared_drive`: `True` if the target Drive is a shared drive and `False` otherwise. This is because handling files in shared drives and owned drives is slightly different. 
-- `main_drive_id`: The folder ID of your root direcotry in Google Drive.
+- `main_drive_id`: The folder ID of your root directory in Google Drive.
 
 4. Please refer to the [appendix](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/google_drive.md#appendix) for more information on Drive ID and Drive folder ID.
 
@@ -53,8 +53,8 @@ def drive_autodetect_folders(self, parent_folder_id:str, folder_name:str, create
 ```
 
 #### **Parameters:**
-- `parent_folder_id`: The folder ID preceeding your target folder. E.g. you are searching/creating the for `folder1/folder2`, you need to provide the ID of `folder1/`. 
-- `folder_name`: Name of the target folder you care seaching/creating.
+- `parent_folder_id`: The folder ID preceding your target folder. For example, if you are searching or creating `folder1/folder2`, you need to provide the ID of `folder1/`.
+- `folder_name`: Name of the target folder you are searching or creating.
 - `create_folder`: `True` to create a folder with the name `folder_name` if the folder with `folder_name` isn't found in the parent folder.
 - `log`: `True` to enable printing messages for logging. `False` otherwise.
 
@@ -70,7 +70,7 @@ folder_data = target_drive.drive_autodetect_folders(
 #### **Use case:**
 - Search for folder by name in target Drive folder.
 - If folder already exists, return found folder data.
-- If folder does not exist
+- If the folder does not exist:
 	- If `create_folder=True`, create a folder by the name `folder_name` and return created folder data.
 	- Return an empty list if `create_folder=False`.
 - `log`: `True` to enable printing messages for logging. `False` otherwise.
@@ -89,7 +89,7 @@ def drive_search_filename(self, parent_folder_id: str, file_name:str) -> List[Tu
 ```
 
 #### **Parameters:**
-- `parent_folder_id`: The folder ID preceeding your target folder. E.g. you are searching/creating the for `folder1/folder2`, you need to provide the ID of `folder1/`. 
+- `parent_folder_id`: The folder ID preceding your target folder. For example, if you are searching or creating `folder1/folder2`, you need to provide the ID of `folder1/`.
 - `file_name`: Name of the file to be searched in the Drive folder.
 
 #### **Method call:**
@@ -147,7 +147,7 @@ def bin_file_to_drive(self, dst_folder_id:str, file_data:List[Tuple], update_dup
 
 #### **Parameters:**
 - `dst_folder_id`: The ID of the Drive folder to upload the files to. It can also be your root Drive folder.
-- `file_data`: List of `(file_name, file_buffer)` pair. Can be obtained from [`df_to_csv_bin`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#df_to_csv_bin) and [`df_to_excel_bin`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#df_to_excel_bin).
+- `file_data`: List of `(file_name, file_buffer)` pairs. Can be obtained from [`df_to_csv_bin`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#df_to_csv_bin) and [`df_to_excel_bin`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/bigquery.md#df_to_excel_bin).
 - `update_dup`: `True` to truncate existing file with the same name in the target folder. `False` to ignore existing files and allow duplicate files.
 - `log`: `True` to enable printing messages for logging. `False` otherwise.
 
@@ -165,7 +165,7 @@ No return value.
 
 ### Drive ID
 
-There are 2 formats of Drive Ids:
+There are two formats of Drive IDs:
 
 #### 1. **My Drive (owned Drive)**
 
@@ -176,7 +176,7 @@ There are 2 formats of Drive Ids:
 
 ##### **Parameters parsing:**
 - You can ignore any parameters containing `drive_id` when working on My Drive.
-- E.g. `main_drive_id` in [`drive_autodetect_folders`]().
+- E.g. `main_drive_id` in [`drive_autodetect_folders`](#drive_autodetect_folders).
 
 #### 2. **Shared Drives**
 
@@ -187,7 +187,7 @@ There are 2 formats of Drive Ids:
 - Usually contains `/u/0/` to indicate user domain.
 
 ##### **Parameters parsing:**
-- You neeed to parse the `DRIVE_ID` part of the link, as a string, into parameters containing `drive_id`.
+- You need to parse the `DRIVE_ID` part of the link, as a string, into parameters containing `drive_id`.
 - In this case, the Drive ID is `0ABcDeFgHiJkLmNoPqRsTuVwXyZ123456`.
 - E.g. `main_drive_id="0ABcDeFgHiJkLmNoPqRsTuVwXyZ123456"` (from [`drive_autodetect_folders`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/google_drive.md#drive_autodetect_folders)).
 
@@ -199,14 +199,14 @@ Each Drive folder is identified by a unique ID.
 #### 1. **My Drive folders**
 - Link format: `https://drive.google.com/drive/folders/FOLDER_ID`.
 - Example: "https://drive.google.com/drive/folders/1ABCdEfGH2IJK-LMnOpQ3RSTuv4WXYZab".
-- Folder IDs typically starts with `1` to indicate a folder in a personal Drive.
+- Folder IDs typically start with `1` to indicate a folder in a personal Drive.
 
 #### 2. **Shared Drive folders:**
 - Link format: `https://drive.google.com/drive/u/0/folders/FOLDER_ID`.
 - Example: "https://drive.google.com/drive/u/0/folders/0ABcDeFgHiJkLmNoPqRsTuVwXyZ123456".
-- Folder IDs typically starts with `0` to indicate a folder in a personal Drive.
+- Folder IDs typically start with `0` to indicate a folder in a shared Drive.
 - Usually contains `/u/0/` to indicate user domain.
 
 #### **Parameters and parsing:**
-- You will always have to parse the `FOLDER_ID` part of the link, as a string, to any parameters containing `folder_id` regardless of if you are working on personal or shared drives.
+- You will always have to parse the `FOLDER_ID` part of the link, as a string, to any parameters containing `folder_id` regardless of whether you are working on personal or shared drives.
 - E.g. `parent_folder_id` from [`drive_autodetect_folders`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/google_drive.md#drive_autodetect_folders) and `dst_folder_id` from [`local_file_to_drive`](https://github.com/nacht29/Python-tools-for-Google/blob/main/docs/google_drive.md#local_file_to_drive).


### PR DESCRIPTION
## Summary
- Add missing periods and tidy grammar in README and doc pages
- Standardize US English spelling and key terminology
- Fix broken links and miscellaneous typos

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9486610c4832a93781abad5b98771